### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM node:dubnium
+FROM node:8.17.0-jessie as builder
 
-WORKDIR /usr/temporal-web
-
-ENV NODE_ENV=production
+WORKDIR /usr/build
 
 # Install app dependencies
 COPY package*.json ./
@@ -10,9 +8,15 @@ RUN npm install --production
 
 # Bundle app source
 COPY . .
-
 # Bundle the client code
 RUN npm run build-production
+RUN mkdir app && mv package.json server.js webpack.config.js .babelrc server dist node_modules temporal-proto ./app
+RUN mkdir -p ./app/protobuf/src && mv protobuf/src ./app/protobuf
 
+# Build final image
+FROM node:8.17.0-jessie-slim
+WORKDIR /usr/app
+ENV NODE_ENV=production
+COPY --from=builder ./usr/build/app ./
 EXPOSE 8088
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
Added multi-stage builds: 1) builder stage 2) final image stage with just the necessary content
Switched to Jessie-lite image.
protobuf folder now only includes with the .proto files
Reduces image size to 400mb:
~100mb jessie-lite image
~300mb temporal-web.

temporal-web details:
18M dist
266M node_modules
4.0K package.json
12M protobuf
76K server
4.0K server.js
208K temporal-proto
4.0K webpack.config.js

Next:

Possibly switch to node:alpine to save ~40mb
look into ways to reduce node_modules (ps. we already install dependencies with --production switch)