### PR TITLE
Shorten input payload view

### DIFF
--- a/client/helpers/get-workflow-input-display.js
+++ b/client/helpers/get-workflow-input-display.js
@@ -1,19 +1,9 @@
 export default input => {
-  if (!input) {
+  if (!input || !input.payloads) {
     return input;
   }
 
-  let parsed = {};
-
-  if (input.jsonStringFull) {
-    parsed = JSON.tryParse(input.jsonStringFull);
-  } else if (input.payloads !== undefined) {
-    parsed = input;
-  } else {
-    return input;
-  }
-
-  const args = parsed.payloads.map((p, i) => ({ [`arg[${i}]`]: p.data }));
+  const args = input.payloads.map((p, i) => ({ [`arg[${i}]`]: p.data }));
 
   return args;
 };

--- a/client/helpers/get-workflow-input-display.js
+++ b/client/helpers/get-workflow-input-display.js
@@ -1,0 +1,19 @@
+export default input => {
+  if (!input) {
+    return input;
+  }
+
+  let parsed = {};
+
+  if (input.jsonStringFull) {
+    parsed = JSON.tryParse(input.jsonStringFull);
+  } else if (input.payloads !== undefined) {
+    parsed = input;
+  } else {
+    return input;
+  }
+
+  const args = parsed.payloads.map((p, i) => ({ [`arg[${i}]`]: p.data }));
+
+  return args;
+};

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -11,5 +11,6 @@ export { default as http } from './http';
 export { default as injectMomentDurationFormat } from './inject-moment-duration-format';
 export { default as jsonTryParse } from './json-try-parse';
 export { default as mapNamespaceDescription } from './map-namespace-description';
+export { default as getWorkflowInputDisplay } from './get-workflow-input-display';
 export { default as timestampToDate } from './timestamp-to-date';
 export { default as shortName } from './short-name';

--- a/client/routes/workflow/helpers/get-history-events.js
+++ b/client/routes/workflow/helpers/get-history-events.js
@@ -3,7 +3,7 @@ import getTimeStampDisplay from './get-time-stamp-display';
 import getEventDetails from './get-event-details';
 import getEventFullDetails from './get-event-full-details';
 import getEventSummary from './get-event-summary';
-import { timestampToDate } from '~helpers';
+import { timestampToDate, getWorkflowInputDisplay } from '~helpers';
 
 const getHistoryEvents = events => {
   if (!events) {
@@ -28,6 +28,15 @@ const getHistoryEvents = events => {
         timeStampDisplay,
         timeElapsedDisplay,
       };
+    })
+    .map(event => {
+      if (event.details && event.details.input) {
+        const input = getWorkflowInputDisplay(event.details.input);
+
+        event.details.input = input;
+      }
+
+      return event;
     })
     .map(event => {
       const details = getEventDetails(event);


### PR DESCRIPTION
Changes the view of workflow input data. Instead of displaying the whole payload object, now only displays the input arguments passed

![image](https://user-images.githubusercontent.com/11838981/81996635-5e097300-9602-11ea-8f3a-019dfb2a24b4.png)



