### PR TITLE
Prepopulate recent namespaces

### DIFF
--- a/client/components/namespace-navigation.vue
+++ b/client/components/namespace-navigation.vue
@@ -82,6 +82,8 @@ export default {
     if (this.$route && this.$route.params && this.$route.params.namespace) {
       this.recordNamespace(this.$route.params.namespace);
     }
+
+    this.getNamespaces();
   },
   methods: {
     recordNamespace(namespace) {
@@ -131,6 +133,23 @@ export default {
         this.namespaceDescCache[d] = mapNamespaceDescription(r);
 
         return this.namespaceDescCache[d];
+      });
+    },
+    getNamespaces(d) {
+      return this.$http(`/api/namespaces`).then(r => {
+        const namespaces = r.namespaces.map(n => n.namespaceInfo.name);
+
+        const newNamespaces = namespaces
+          .filter(n => !this.recentNamespaces.includes(n))
+          .filter(n => n !== 'temporal-system');
+
+        this.recentNamespaces.push(...newNamespaces);
+        this.recentNamespaces = this.recentNamespaces.slice(0, 15);
+
+        localStorage.setItem(
+          'recent-namespaces',
+          JSON.stringify(this.recentNamespaces)
+        );
       });
     },
     checkValidity: debounce(function checkValidity() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temporal-web",
-  "version": "0.21.1",
+  "version": "0.23.0",
   "description": "Temporal Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/server/middleware/workflow-client.js
+++ b/server/middleware/workflow-client.js
@@ -188,7 +188,7 @@ WorkflowClient.prototype.listNamespaces = async function({
 }) {
   const req = { pageSize, nextPageToken };
 
-  const res = await this.client.listNamespacesAync(req);
+  const res = await this.client.listNamespacesAsync(req);
 
   return uiTransform(res);
 };


### PR DESCRIPTION
On namespaces page load fetches and populates 'Recent Namespaces' with the namespaces existing on the server

![image](https://user-images.githubusercontent.com/11838981/82269605-04b58280-9927-11ea-8060-82300efe5217.png)
