### PR TITLE
Show workflows page by default if there is only one namespace

### DIFF
--- a/client/components/namespace-navigation.vue
+++ b/client/components/namespace-navigation.vue
@@ -83,7 +83,14 @@ export default {
       this.recordNamespace(this.$route.params.namespace);
     }
 
-    this.getNamespaces();
+    this.getNamespaces().then(() => {
+      if (this.recentNamespaces.length == 1) {
+        const namespace = this.recentNamespaces[0];
+        const url = this.namespaceLink(namespace);
+
+        this.$router.push(url);
+      }
+    });
   },
   methods: {
     recordNamespace(namespace) {


### PR DESCRIPTION
Addresses #32 
Namespace page doesn't provide much usefulness. With this PR we are skipping this page and navigate directly to a namespace, if there is only one available