### PR TITLE
Support Failure/FailureInfo proto changes

### DIFF
--- a/client/routes/workflow/helpers/summarize-events.js
+++ b/client/routes/workflow/helpers/summarize-events.js
@@ -115,4 +115,7 @@ export const summarizeEvents = {
 
     return summary;
   },
+  WorkflowExecutionFailed: d => {
+    return { message: d.failure.message };
+  },
 };

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -69,10 +69,10 @@
           </router-link>
         </dd>
       </div>
-      <div class="workflow-result" v-if="result">
+      <div class="workflow-result" v-if="resultView">
         <dt>Result</dt>
         <dd>
-          <data-viewer :item="result" :title="workflowId + ' Result'" />
+          <data-viewer :item="resultView" :title="workflowId + ' Result'" />
         </dd>
       </div>
       <div class="workflow-id">
@@ -172,6 +172,22 @@ export default {
       return moment(this.workflow.workflowExecutionInfo.startTime).format(
         'dddd MMMM Do, h:mm:ss a'
       );
+    },
+    resultView() {
+      if (!this.result || !this.result.jsonStringFull) {
+        return this.result;
+      }
+
+      const res = JSON.parse(this.result.jsonStringFull);
+
+      if (res.failure) {
+        return {
+          jsonStringDisplay: { message: res.failure.message },
+          jsonStringFull: res,
+        };
+      }
+
+      return this.result;
     },
   },
   methods: {


### PR DESCRIPTION
* Updated gRPC contract to support Failure/FailureInfo changes to show errors https://github.com/temporalio/temporal/pull/397
* Changed Summary views focus on Failure message instead of the whole failure payload