### PR TITLE
Order workflows by start time and close time

### DIFF
--- a/client/routes/namespace/workflow-list.vue
+++ b/client/routes/namespace/workflow-list.vue
@@ -110,6 +110,7 @@
 <script>
 import moment from 'moment';
 import debounce from 'lodash-es/debounce';
+import orderBy from 'lodash-es/orderBy';
 import pagedGrid from '~components/paged-grid';
 import { DateRangePicker } from '~components';
 import {
@@ -311,7 +312,14 @@ export default pagedGrid({
           .then(res => {
             this.npt = res.nextPageToken;
             this.loading = false;
-            const formattedResults = res.executions.map(data => ({
+
+            const executions = orderBy(
+              res.executions,
+              ['startTime', 'closeTime'],
+              ['desc', 'desc']
+            );
+
+            const formattedResults = executions.map((data) => ({
               workflowId: data.execution.workflowId,
               runId: data.execution.runId,
               workflowName: data.type.name,

--- a/client/routes/namespace/workflow-list.vue
+++ b/client/routes/namespace/workflow-list.vue
@@ -142,7 +142,7 @@ export default pagedGrid({
     };
   },
   created() {
-    this.$http(`/api/namespaces/${this.namespace}`).then(r => {
+    this.$http(`/api/namespaces/${this.namespace}`).then((r) => {
       this.maxRetentionDays =
         Number(r.config.workflowExecutionRetentionPeriodInDays) || 30;
 
@@ -203,7 +203,7 @@ export default pagedGrid({
     status() {
       return !this.$route.query || !this.$route.query.status
         ? this.statuses[0]
-        : this.statuses.find(s => s.value === this.$route.query.status);
+        : this.statuses.find((s) => s.value === this.$route.query.status);
     },
     statusName() {
       return this.status.value;
@@ -300,8 +300,8 @@ export default pagedGrid({
         this.error = undefined;
 
         return this.$http(url, { query })
-          .then(res => {
-            res.executions = res.executions.map(data => ({
+          .then((res) => {
+            res.executions = res.executions.map((data) => ({
               ...data,
               startTime: timestampToDate(data.startTime),
               closeTime: timestampToDate(data.closeTime),
@@ -309,15 +309,13 @@ export default pagedGrid({
 
             return res;
           })
-          .then(res => {
+          .then((res) => {
             this.npt = res.nextPageToken;
             this.loading = false;
 
-            const executions = orderBy(
-              res.executions,
-              ['startTime', 'closeTime'],
-              ['desc', 'desc']
-            );
+            const orderField =
+              this.state === 'open' ? 'startTime' : 'closeTime';
+            const executions = orderBy(res.executions, orderField, ['desc']);
 
             const formattedResults = executions.map((data) => ({
               workflowId: data.execution.workflowId,
@@ -336,7 +334,7 @@ export default pagedGrid({
 
             return this.results;
           })
-          .catch(e => {
+          .catch((e) => {
             this.npt = undefined;
             this.loading = false;
             this.error = (e.json && e.json.message) || e.status || e.message;


### PR DESCRIPTION
Resolves #43 
Ordering now will be done by Start Time and Close Time of the workflows

These times refer to the `workflow` and not the actual `workflow run` times. This means it is still not ideal since it doesn't guarantee perfect ordering according to `workflow run` start time, though should typically match the correct ordering.  Otherwise to get the start and close times of a workflow run, so far it would require to call DescribeWorkflowDetails which is not ideal from performance since it would have to be called for each workflow separately